### PR TITLE
Add extra_pip_install_args option to the pyvan build

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ import pyvan
 OPTIONS = {"main_file_name": "main.py", 
             "show_console": False,
             "use_existing_requirements": False,
+            "extra_pip_install_args": [],
             "use_pipreqs": True,
             "install_only_these_modules": [],
             "exclude_modules": [],
@@ -47,6 +48,9 @@ pyvan.build(OPTIONS)
 
 * **use_existing_requirements**: True, ==> if specified pyvan will use an existing requirements.txt file instead of generating one using the: 
                                        use_pipreqs, install_only_these_modules, exclude_modules, and include_modules options
+
+* **extra_pip_install_args**: [], ==> pyvan will append the provided arguments to the pip install command during installation of the stand-alone distribution. 
+                                  The arguments should be specified as a list of strings (for example: `["-f", "/local/dir"]`) 
 
 * **use_pipreqs**: True,         ==> pipreqs tries to minimize the size of your app by looking at your imports 
                                  (best way is to use a virtualenv to ensure a smaller size, if fails will do pip freeze)

--- a/src/pyvan.py
+++ b/src/pyvan.py
@@ -154,8 +154,11 @@ def prepare_for_pip_install(pth_file, zip_pyfile):
 # In[ ]:
 
 
-def install_requirements():
-    """Install pip and the modules from requirements.txt file"""
+def install_requirements(extra_pip_install_args = None):
+    """
+        Install pip and the modules from requirements.txt file
+        - extra_pip_install_args (optional `List[str]`) : pass these additional arguments to the pip install command
+    """
     
     print("Installing pip..")
 
@@ -169,19 +172,23 @@ def install_requirements():
     os.chdir("Scripts")
     print("Moved runtime to Scripts folder: ", os.getcwd())
 
+    if extra_pip_install_args is not None:
+        extra_args_str = " " + " ".join(extra_pip_install_args)
+    else:
+        extra_args_str = ""
+
     try:
-        cmd = "pip3.exe install --no-cache-dir --no-warn-script-location -r ../requirements.txt"
+        cmd = "pip3.exe install --no-cache-dir --no-warn-script-location -r ../requirements.txt" + extra_args_str
         execute_os_command(cmd)
     except:
-        
         print("Installing modules one by one..")
-        
+
         with open("../requirements.txt", "r") as f:
             modules = f.read().splitlines()
-        
+
         for module in modules:
             try:
-                cmd = "pip3.exe install --no-cache-dir --no-warn-script-location " + module
+                cmd = "pip3.exe install --no-cache-dir --no-warn-script-location " + module + extra_args_str
                 execute_os_command(cmd)
             except:
                 print("FAILED TO INSTALL ", module)
@@ -287,7 +294,7 @@ def build(OPTIONS):
 
     make_startup_batch(OPTIONS)
     prepare_for_pip_install(pth_file, zip_pyfile)
-    install_requirements()
+    install_requirements(extra_pip_install_args=OPTIONS.get("extra_pip_install_args", []))
     
     os.chdir(BASE_DIR)
     


### PR DESCRIPTION
This PR addresses the issue that sometimes pip install requires to be run with additional flags, like finding a certain package that is not on PyPi. e.g.: in my use-case:

```pip install torch==1.7.1+cpu torchvision==0.8.2+cpu torchaudio===0.7.2 -f https://download.pytorch.org/whl/torch_stable.html```

This PR fixes that by adding a new `extra_pip_install_args` option (as a list of strings) which feeds the additional arguments to the pip install during the distribution build.

Additionally, I have updated the README.md accordingly.