### PR TITLE
Big refactor of the core pyvan build method with a focus on disentangling the required build directories for more custom control

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,28 +23,33 @@ Make a "van.py" file next to the "main.py" file (entry point of your program)
 Paste the code bellow:
 
 ```py
-import pyvan 
+import pyvan
 
-OPTIONS = {"main_file_name": "main.py", 
-            "show_console": False,
-            "use_existing_requirements": False,
-            "extra_pip_install_args": [],
-            "use_pipreqs": True,
-            "install_only_these_modules": [],
-            "exclude_modules": [],
-            "include_modules": [],
-            "path_to_get_pip_and_python_embeded_zip": ""
-            }
+OPTIONS = {
+    "main_file_name": "main.py",
+    "show_console": False,
+    "use_existing_requirements": False,
+    "extra_pip_install_args": [],
+    "use_pipreqs": True,
+    "install_only_these_modules": [],
+    "exclude_modules": [],
+    "include_modules": [],
+    "path_to_get_pip_and_python_embeded_zip": "",
+    "build_dir": "dist",
+    "pydist_sub_dir": "pydist",
+    "source_sub_dir": "",
+}
 
-pyvan.build(OPTIONS)
+pyvan.build(**OPTIONS)
+
  
 ```
 
 ### Configurations
 
-* **main_file_name**: "main.py", ==> the entry point of the application
+* **main_file_name**: "main.py",  ==> the entry point of the application
 
-* **show_console**: True,        ==> show console window or not (for a service or GUI app)
+* **show_console**: True,         ==> show console window or not (for a service or GUI app)
 
 * **use_existing_requirements**: True, ==> if specified pyvan will use an existing requirements.txt file instead of generating one using the: 
                                        use_pipreqs, install_only_these_modules, exclude_modules, and include_modules options
@@ -52,8 +57,8 @@ pyvan.build(OPTIONS)
 * **extra_pip_install_args**: [], ==> pyvan will append the provided arguments to the pip install command during installation of the stand-alone distribution. 
                                   The arguments should be specified as a list of strings (for example: `["-f", "/local/dir"]`) 
 
-* **use_pipreqs**: True,         ==> pipreqs tries to minimize the size of your app by looking at your imports 
-                                 (best way is to use a virtualenv to ensure a smaller size, if fails will do pip freeze)
+* **use_pipreqs**: True,          ==> pipreqs tries to minimize the size of your app by looking at your imports 
+                                  (best way is to use a virtualenv to ensure a smaller size, if fails will do pip freeze)
   
 * **install_only_these_modules**: [], ==> pyvan will install only the modules mentioned here
 
@@ -61,7 +66,15 @@ pyvan.build(OPTIONS)
 
 * **include_modules**: [],        ==> modules to include in the bundle
 
-* **path_to_get_pip_and_python_embeded_zip** ==> by default is the Download path (path to 'get-pip.py' and 'python-x.x.x-embed-amdxx.zip' files)
+* **path_to_get_pip_and_python_embeded_zip**: "", ==> by default is the Download path (path to 'get-pip.py' and 'python-x.x.x-embed-amdxx.zip' files)
+
+* **build_dir**: "dist",          ==> the directory in which pyvan will create the stand-alone distribution
+
+* **pydist_sub_dir**: "pydist",   ==> a sub directory relative to `build_dir` where the stand-alone python distribution will be installed, if left empty this is the same as the `build-dir` 
+
+* **source_sub_dir**: "",         ==> a sub directory relative to `build_dir` where the to execute python files will be installed, if left empty this is the same as the `build-dir` 
+
+* **input_dir**: ".",             ==> the directory to get the main_file_name file from, by default this is the current working directory 
 
 * **icon_location**: "TODO" ==> for now pyvan will create a .bat file which links the main_file_name with python.exe
                             in the future will add something that will convert the .bat to .exe and you will be able to set it an icon too

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ OPTIONS = {
     "install_only_these_modules": [],
     "exclude_modules": [],
     "include_modules": [],
-    "path_to_get_pip_and_python_embeded_zip": "",
+    "path_to_get_pip_and_python_embedded_zip": "",
     "build_dir": "dist",
     "pydist_sub_dir": "pydist",
     "source_sub_dir": "",
@@ -66,7 +66,7 @@ pyvan.build(**OPTIONS)
 
 * **include_modules**: [],        ==> modules to include in the bundle
 
-* **path_to_get_pip_and_python_embeded_zip**: "", ==> by default is the Download path (path to 'get-pip.py' and 'python-x.x.x-embed-amdxx.zip' files)
+* **path_to_get_pip_and_python_embedded_zip**: "", ==> by default is the Download path (path to 'get-pip.py' and 'python-x.x.x-embed-amdxx.zip' files)
 
 * **build_dir**: "dist",          ==> the directory in which pyvan will create the stand-alone distribution
 


### PR DESCRIPTION
### The problem and solution

The problem I had with pyvan is that the python distribution and input source files were always put together in the `dist` folder. It is cleaner to provide separate subfolders to install the python-dist and the sources in separate locations in the build-folder if desired. Doing this we can still create a batch file that properly calls the python-dist executables and links those to the sources.

### The changes

This PR implements this idea with backward compatibility, e.g. the following settings will install as usual:

```python
OPTIONS = {
...
"build_dir" : "dist",
"pydist_sub_dir": "",
"source_sub_dir": ""
...
}
```

But the following will install the python distribution to a subdirectory "dist/pydist" and the input files to "dist/sources":

```python
OPTIONS = {
...
"build_dir" : "dist",
"pydist_sub_dir": "pydist",
"source_sub_dir": "sources"
...
}
```


* separated the core directories for installation:
  * `input_dir`       - the directory where the `main_file_name` file, all other required files, and optionally the requirements.txt file can be found (can be omitted, then it will just be the `os.getcwd()`)
  * `build_dir`       - "dist" the primary folder to install all the stand-alone build files to
  * `pydist_sub_dir`  - target subdirectory in the `build_dir` to put the stand-alone python distribution (can be set to `""` for the `build_dir`)
  * `source_sub_dir`  - target subdirectory in the `build_dir` to put a copy of the `main_file_name` python file and all other "input_dir" files  (can be set to `""` for the `build_dir`)

* The batch file will always be installed directly in the `build_dir` but now links depending on where it is installed, it will always correctly link to the python distribution and the copied source files, independent of install location.

* pyvan build method no longer requires an OPTIONS dict, but rather uses arguments now
  * this makes it easier to make into a command line interface
  * this makes it easier to set default values, which will result in smaller/cleaner configurations

Note options can still be passed as a dict by using:

```python
pyvan.build(**OPTIONS)
```

* The `requirements.txt` for the build is now ALWAYS copied/created inside the `build_dir` now, which prevents overriding a `requirements.txt` file in the `input_dir`

* The build configuration will be printed to the user to see what pyvan will do in the build.

* Removed the need for `os.chdir` by passing all the correct working dirs directly to the subprocess with the `cwd` argument

* Extracted some of the methods within the build step for clarity

* README has been adjusted accordingly

### Considerations

@ClimenteA I know this is kind of a big PR, I have only tested it for my own application with various settings for `input_dir`, `build_dir`, `pydist_sub_dir`, and `source_sub_dir`. For me, they all work, but it might require more tests for your use-cases

If there is something unclear or you want something changed, please don't hesitate to discuss it.

#### Some caveats: 
* The `shutils.copy_tree(..., dirs_exist_ok=True)` argument which I used might not work for Python versions < 3.8. So we might need something else if that's a problem for you.
* The batch file is created in a slightly different manner than before, I don't expect any problems, but still good to know:
  * It uses `%~dp0` to find the relative path to where the script is
  * It uses `%*` to pass additional arguments provided in a terminal to python script called from the batch file
* One part of pyvan that's undertested is the auto resolution of the requirements using `pipreqs` and `pip freeze` so you might want to focus testing those

#### Cool features:

With this PR we can now do stuff like this, for very minimalistic builds:

```py
import pyvan

pyvan.build(
    main_file_name="main.py",
    use_pipreqs=True
)

```